### PR TITLE
Data appears in the search result page error_Publication date_materials_num

### DIFF
--- a/search_engine/search/frontend/src/pages/SearchResultsPage.js
+++ b/search_engine/search/frontend/src/pages/SearchResultsPage.js
@@ -206,7 +206,7 @@ const SearchResultsPage = () => {
                 <FilterCard title="Tags" items={facets.tags || []} field="tags" selectedFilters={selectedFilters} handleFilter={handleFilter} />
 
                 {facets.publication_dates && (
-                  <FilterCard title="Publication Date" items={facets.publication_dates} field="publication_date" selectedFilters={selectedFilters} handleFilter={handleFilter} />
+                  <FilterCard title="Publication Date" items={facets.publication_dates} field="publication_dates" selectedFilters={selectedFilters} handleFilter={handleFilter} />
                 )}
                 {facets.submission_dates && (
                   <FilterCard title="Submission Date" items={facets.submission_dates} field="submission_dates" selectedFilters={selectedFilters} handleFilter={handleFilter} />


### PR DESCRIPTION
 This PR related to #71 

Problem: The publication date filter in the FilterCard displays an incorrect count. For example, it may indicate that there are 2 materials available for a selected date range, but upon selecting it, no results are shown.

solution:  field="publication_date" to field="publication_dates"

Data mismatch due to missing “s” !!!

 This PR closes #71 
