### PR TITLE
First try with the RAG chatbot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,20 @@ services:
     volumes:
       - ./search_engine/search/backend/wordcloud/static:/app/static
 
+  chatbot_backend:
+    build:
+      context: ./search_engine/chatbot
+      dockerfile: Dockerfile
+    container_name: chatbot_backend
+    environment:
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTICSEARCH_PORT=9200
+      - HF_TOKEN
+    depends_on:
+      - elasticsearch
+    ports:
+      - "5002:5000"
+
   frontend:
     build:
       context: ./search_engine/search/frontend  # Path to the frontend code
@@ -63,6 +77,7 @@ services:
     depends_on:
       - appsubmitter_backend
       - search_backend
+      - chatbot_backend
     environment:
       - REACT_APP_BACKEND_URL=http://localhost:5001
 

--- a/folder structure.txt
+++ b/folder structure.txt
@@ -2,12 +2,17 @@
 ├── images
 │   ├── search_results.png
 │   └── submit_materials.png
-├── nfdi_search_engine_design
+├── search_engine
 │   ├── Elasticsearch
 │   ├── appsubmitter_backend
 │   │   ├── Dockerfile
 │   │   ├── requirements_submitter.txt
 │   │   └── submitter.py
+│   ├── chatbot/
+│   │   ├── chatbot.py
+│   │   ├── llm_utilities.py
+│   │   ├── requirements_chatbot.txt
+│   │   └── Dockerfile
 │   ├── search
 │   │   ├── backend
 │   │   │   ├── data.json

--- a/search_engine/chatbot/Dockerfile
+++ b/search_engine/chatbot/Dockerfile
@@ -1,0 +1,24 @@
+# Use the official Python image as a base
+FROM python:3.12-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements_chatbot.txt .
+
+# Install the dependencies
+RUN pip install --upgrade pip && pip install -r requirements_chatbot.txt
+
+# Copy the rest of the application code into the container
+COPY . .
+
+# Expose the port that the Flask app runs on
+EXPOSE 5000  
+
+# Run the application
+CMD ["python", "chatbot.py"]

--- a/search_engine/chatbot/chatbot.py
+++ b/search_engine/chatbot/chatbot.py
@@ -1,0 +1,146 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from elasticsearch import Elasticsearch, ConnectionError
+from llm_utilities import LLMUtilities
+import logging
+import platform
+import time
+
+# Flask app setup
+app = Flask(__name__)
+CORS(app)
+
+# Logging setup
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Hardware Information
+SYSTEM_INFO = {
+    "Machine": platform.node(),
+    "Processor": platform.processor(),
+    "RAM": "64GB",
+    "GPU": "Intel Arc Graphics (shared memory: 37GB)"
+}
+logger.info(f"System Info: {SYSTEM_INFO}")
+
+# Function to connect to Elasticsearch with retry logic
+def connect_elasticsearch():
+    """
+    Connects to Elasticsearch with retry logic.
+    Returns:
+        Elasticsearch instance if connection is successful, otherwise raises an exception.
+    """
+    es = None
+    max_attempts = 60
+    for attempt in range(max_attempts):
+        try:
+            es = Elasticsearch(
+                [{"host": "elasticsearch", "port": 9200, "scheme": "http"}],
+                timeout=30
+            )
+            if es.ping():
+                logger.info("Connected to Elasticsearch")
+                return es
+            else:
+                logger.error("Elasticsearch ping failed")
+        except ConnectionError:
+            logger.warning(f"Elasticsearch not ready, attempt {attempt + 1}/{max_attempts}, retrying in 10 seconds...")
+            time.sleep(10)
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}")
+            time.sleep(10)
+    raise Exception("Could not connect to Elasticsearch after several attempts")
+
+# Connect to Elasticsearch
+es = connect_elasticsearch()
+
+# Initialize LLM Utilities
+use_gpu = False  # Set to True to enable GPU inference
+llm_util = LLMUtilities(use_gpu=use_gpu)
+
+# Elasticsearch-based document retrieval
+def retrieve_documents(query, top_k=3):
+    """
+    Retrieves relevant documents from Elasticsearch based on the query.
+    Args:
+        query (str): The search query.
+        top_k (int): Number of top documents to retrieve.
+    Returns:
+        list: A list of retrieved documents.
+    """
+    try:
+        response = es.search(
+            index="bioimage-training",
+            body={
+                "query": {
+                    "multi_match": {
+                        "query": query,
+                        "fields": ["name^3", "description", "tags", "authors", "type", "license"],
+                        "type": "best_fields",
+                    }
+                }
+            },
+            size=top_k,
+        )
+        documents = [
+            {
+                "name": hit["_source"].get("name", "Unnamed"),
+                "description": hit["_source"].get("description", "No description available"),
+                "url": hit["_source"].get("url", ""),
+            }
+            for hit in response["hits"]["hits"]
+        ]
+        return documents
+    except Exception as e:
+        logger.error(f"Error retrieving documents: {e}")
+        return []
+
+# RAG-based response generation
+def generate_response(query, documents):
+    """
+    Generates a response using retrieved documents and the query.
+    Args:
+        query (str): The search query.
+        documents (list): List of retrieved documents.
+    Returns:
+        str: Generated response.
+    """
+    context = "\n".join(
+        [f"- {doc['name']}: {doc['description']}" for doc in documents]
+    )
+    prompt = f"""
+    Based on the following documents, answer the user's question concisely and include relevant links.
+
+    ## Documents
+    {context}
+
+    ## Question
+    {query}
+    """
+    return llm_util.generate_response(prompt)
+
+# Chatbot API endpoint
+@app.route("/api/chat", methods=["POST"])
+def chat():
+    """
+    Chat endpoint to process user queries and generate responses.
+    """
+    user_query = request.json.get("query", "")
+    if not user_query:
+        return jsonify({"error": "Query cannot be empty"}), 400
+
+    # Retrieve relevant documents
+    documents = retrieve_documents(user_query)
+
+    if not documents:
+        return jsonify({"response": "No relevant documents found.", "sources": []})
+
+    # Generate chatbot response
+    reply = generate_response(user_query, documents)
+
+    return jsonify({"response": reply, "sources": documents})
+
+# Main entry point
+if __name__ == "__main__":
+    logger.info(f"Starting chatbot on {'GPU' if use_gpu else 'CPU'}...")
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/search_engine/chatbot/llm_utilities.py
+++ b/search_engine/chatbot/llm_utilities.py
@@ -1,0 +1,63 @@
+import os
+import logging
+from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM
+
+logger = logging.getLogger(__name__)
+
+class LLMUtilities:
+    def __init__(self, model_name="meta-llama/Llama-2-7b", use_gpu=False):
+        """
+        Initialize the utility with the specified model and device configuration.
+
+        Args:
+            model_name (str): The Hugging Face model name to load.
+            use_gpu (bool): Whether to use GPU for inference.
+        """
+        self.model_name = model_name
+        self.use_gpu = use_gpu
+        self.token = os.getenv("HF_TOKEN")
+        if not self.token:
+            logger.error("HF_TOKEN is not set in the environment variables. Please set it to access the Hugging Face model.")
+            raise EnvironmentError("Missing Hugging Face token.")
+        self.pipeline = self._load_model()
+
+    def _load_model(self):
+        """
+        Load the specified model and tokenizer, optimized for GPU if enabled.
+
+        Returns:
+            pipeline: The Hugging Face pipeline for text generation.
+        """
+        logger.info(f"Loading model '{self.model_name}' with {'GPU' if self.use_gpu else 'CPU'} inference.")
+        try:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.model_name,
+                use_auth_token=self.token
+            )
+            tokenizer = AutoTokenizer.from_pretrained(
+                self.model_name,
+                use_auth_token=self.token
+            )
+            return pipeline("text-generation", model=model, tokenizer=tokenizer, device=0 if self.use_gpu else -1)
+        except Exception as e:
+            logger.error(f"Error loading model '{self.model_name}': {e}")
+            raise e
+
+    def generate_response(self, prompt, max_length=200, num_return_sequences=1):
+        """
+        Generate a response based on the provided prompt.
+
+        Args:
+            prompt (str): The input prompt for the model.
+            max_length (int): Maximum length of the generated response.
+            num_return_sequences (int): Number of response sequences to generate.
+
+        Returns:
+            str: The generated response.
+        """
+        try:
+            response = self.pipeline(prompt, max_length=max_length, num_return_sequences=num_return_sequences)
+            return response[0]["generated_text"]
+        except Exception as e:
+            logger.error(f"Error during response generation: {e}")
+            return "Sorry, I couldn't generate a response."

--- a/search_engine/chatbot/requirements_chatbot.txt
+++ b/search_engine/chatbot/requirements_chatbot.txt
@@ -1,0 +1,7 @@
+elasticsearch
+flask
+flask-cors
+pyyaml
+requests
+transformers
+optimum[openvino]


### PR DESCRIPTION
This is a version of the chatbot for the first attempt to set up the RAG chatbot, which requires setting up the HF token locally as well as still needing to adjust the timing of the elasticsearch and chatbot startups

For here "def connect_elasticsearch():
    """
    Connects to Elasticsearch with retry logic.
    Returns:
        Elasticsearch instance if connection is successful, otherwise raises an exception.
    """
    es = None
    max_attempts = 60
    for attempt in range(max_attempts):
        try:
            es = Elasticsearch(
                [{"host": "elasticsearch", "port": 9200, "scheme": "http"}],
                timeout=30
            )
            if es.ping():
                logger.info("Connected to Elasticsearch")
                return es
            else:
                logger.error("Elasticsearch ping failed")
        except ConnectionError:
            logger.warning(f"Elasticsearch not ready, attempt {attempt + 1}/{max_attempts}, retrying in 10 seconds...")
            time.sleep(10)
        except Exception as e:
            logger.error(f"Unexpected error: {e}")
            time.sleep(10)
    raise Exception("Could not connect to Elasticsearch after several attempts")"